### PR TITLE
FCLDALP-16 [MAIN] Use buildx output builder for cache export (Focela)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -196,7 +196,7 @@ jobs:
         env:
           DOCKER_CONFIG: ${{ github.workspace }}/.docker-ghcr
         with:
-          builder: default
+          builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./${{ env.build_file }}
           platforms: ${{ matrix.platforms }}

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -191,7 +191,7 @@ jobs:
         env:
           DOCKER_CONFIG: ${{ github.workspace }}/.docker-ghcr
         with:
-          builder: default
+          builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./${{ env.build_file }}
           platforms: ${{ matrix.platforms }}


### PR DESCRIPTION
### Description
Fix Docker buildx cache export errors by using buildx output builder reference instead of default builder. This ensures the docker-container driver with moby/buildkit image is properly utilized for cache export operations, resolving persistent "Cache export is not supported for the docker driver" errors.

## Changes Made

### Bug Fixes
- Fixed Docker buildx cache export driver errors in build workflows
- Resolved default builder compatibility issues with cache export
- Implemented buildx output builder configuration for all builds
- Applied fixes to both automated and manual build workflows

### Files Modified
- **.github/workflows/main.yml**: Changed to use buildx output builder
- **.github/workflows/manual.yml**: Changed to use buildx output builder

## Benefits

- Eliminates "Cache export is not supported for the docker driver" errors
- Ensures stable cache export operations across all Docker buildx operations
- Provides consistent cache export support with docker-container driver
- Maintains build performance with optimized BuildKit image configuration

## Core Functionality

### Builder Configuration Fixes
- Replaced `builder: default` with `builder: ${{ steps.buildx.outputs.name }}`
- Maintained `driver: docker-container` with `driver-opts: image=moby/buildkit:latest`
- Ensured builder uses docker-container driver for cache export compatibility
- Preserved all existing authentication and cache configuration fixes

### Workflow Synchronization
- Applied identical fixes to both main.yml and manual.yml workflows
- Enhanced cache export stability for multi-platform builds
- Ensured backward compatibility with current workflow structure
- Maintained registry-based cache configuration

## Technical Specifications

- **Builder Type**: Changed from default to buildx output builder reference
- **Driver Configuration**: docker-container with moby/buildkit:latest image
- **Cache Support**: Full cache export compatibility with docker-container driver
- **Workflows**: Fixed both main.yml and manual.yml
- **Compatibility**: Stable cache export operations across all builds
- **Performance**: Consistent build performance with proper cache support

## Development Status

- **Current Phase**: Bug fix implementation
- **Next Steps**: Test workflows to verify cache export resolution
- **Planned Testing**: Verify successful builds with cache operations
- **Future Enhancements**: Monitor cache performance and stability

## Checklist

- [x] Replace default builder with buildx output builder reference
- [x] Maintain docker-container driver configuration
- [x] Apply fix to main.yml workflow
- [x] Apply fix to manual.yml workflow
- [x] Preserve existing authentication and cache fixes
- [x] Ensure docker-container driver compatibility
- [ ] Test automated workflow builds with buildx output builder
- [ ] Test manual workflow dispatch builds with buildx output builder
- [ ] Verify successful cache export operations
- [ ] Validate cache performance across matrix variants

**Note:** All cache export driver fixes have been implemented and are ready for testing. The changes maintain backward compatibility while resolving cache export errors and ensuring stable cache operations.

## Related Issue

Refs: FCLDALP-16